### PR TITLE
[+] add: more ads for empty content

### DIFF
--- a/src/components/async/Footer.js
+++ b/src/components/async/Footer.js
@@ -11,8 +11,7 @@ const Container = styled.footer`
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	margin-top: 7.5rem;
-	margin-bottom: 4rem;
+	margin: 4rem 0;
 	border-top: 0.475rem dashed ${(props) => props.theme.borderColor};
 `;
 

--- a/src/components/common/FetcherComponents.js
+++ b/src/components/common/FetcherComponents.js
@@ -26,7 +26,7 @@ const ContainerNoMore = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 1.6rem 0;
+  margin: 1.6rem 0 4.8rem;
   min-width: 27.6rem;
   overflow: hidden;
 `;

--- a/src/routes/ClassPage.js
+++ b/src/routes/ClassPage.js
@@ -74,7 +74,7 @@ const ReviewTitle = styled.div`
 	margin-top: 2.2rem;
 `;
 
-const ADS_POSITION_OFFSET = 9
+const ADS_POSITION_OFFSET = 6
 
 const ClassPage = (props) => {
 	const { classID, fetchTarget, setFetchTarget } = props;
@@ -191,6 +191,7 @@ const ClassPage = (props) => {
 								</NoMoreCustom>
 								<PrimaryButton onClick={handleNewReview}>เพิ่มรีวิว</PrimaryButton>
 							</ContainerNoMore>
+              <AdDisplayCard />
 							<Footer />
 						</>
 					)
@@ -215,6 +216,7 @@ const ClassPage = (props) => {
 								</NoMoreCustom>
 								<PrimaryButton onClick={() => setQuestionModal(true)}>ถามคำถาม</PrimaryButton>
 							</ContainerNoMore>
+              <AdDisplayCard />
 							<Footer />
 						</>
 					)
@@ -239,6 +241,7 @@ const ClassPage = (props) => {
 								</NoMoreCustom>
 								<PrimaryButton onClick={handleNewReview}>เพิ่มรีวิว</PrimaryButton>
 							</ContainerNoMore>
+              <AdDisplayCard />
 							<Footer />
 						</>
 					)

--- a/src/routes/HomePage.js
+++ b/src/routes/HomePage.js
@@ -21,7 +21,7 @@ const HomeTitle = styled.div`
 	width: fit-content;
 `;
 
-const ADS_POSITION_OFFSET = 9
+const ADS_POSITION_OFFSET = 6
 
 const HomePage = (props) => {
 	const { fetchTarget, setFetchTarget } = props;
@@ -115,6 +115,7 @@ const HomePage = (props) => {
 									)}
 								</NoMoreCustom>
 							</ContainerNoMore>
+              <AdDisplayCard />
 							<Footer />
 						</>
 					)
@@ -138,6 +139,7 @@ const HomePage = (props) => {
 									)}
 								</NoMoreCustom>
 							</ContainerNoMore>
+              <AdDisplayCard />
 							<Footer />
 						</>
 					)
@@ -161,6 +163,7 @@ const HomePage = (props) => {
 									)}
 								</NoMoreCustom>
 							</ContainerNoMore>
+              <AdDisplayCard />
 							<Footer />
 						</>
 					)

--- a/src/routes/ReviewPage.js
+++ b/src/routes/ReviewPage.js
@@ -108,6 +108,7 @@ const ReviewPage = (props) => {
 								<NoMoreCard />
 							</NoMoreCustom>
 						</ContainerNoMore>
+            <AdDisplayCard />
 					</>
 				) : review ? (
           <>
@@ -117,7 +118,10 @@ const ReviewPage = (props) => {
 				) : loading ? (
 					<ReviewSkeletonA />
 				) : isAvailable ? (
-					<ReviewCard isBadge={false} currentRoute={"REVIEW"} {...review} />
+          <>
+            <ReviewCard isBadge={false} currentRoute={"REVIEW"} {...review} />
+            <AdDisplayCard />
+          </>
 				) : (
 					<>
 						<ContainerNoMore>
@@ -126,6 +130,7 @@ const ReviewPage = (props) => {
 								<NoMoreCard />
 							</NoMoreCustom>
 						</ContainerNoMore>
+            <AdDisplayCard />
 					</>
 				)}
 				{/* {review ? (


### PR DESCRIPTION
## Purpose / Description
- add more ads for empty content (review, question, and recap)
- reduce ads offset to `6`

## Changes made / Changes Checklist
- add ads to the container no more content for each page

## Screenshots
<img width="453" alt="Screen Shot 2566-01-02 at 23 35 35" src="https://user-images.githubusercontent.com/23165145/210259405-9d205132-710a-4131-92ac-6ec9b6fcb6df.png">

<img width="399" alt="Screen Shot 2566-01-02 at 23 36 29" src="https://user-images.githubusercontent.com/23165145/210259412-b9e49f9f-a64b-4224-8c56-42ffd2ea729d.png">
