### PR TITLE
Hide google-auto-placed ads between card list and increase ad frequency 

### DIFF
--- a/src/components/common/FetcherComponents.js
+++ b/src/components/common/FetcherComponents.js
@@ -11,6 +11,10 @@ const DetailTitle = styled(Heading1)`
 const AdaptorReviews = styled.div`
   width: 100%;
   margin: 0 auto;
+
+  .google-auto-placed {
+    display: none !important;
+  }
 `;
 
 const LastReview = styled.div`

--- a/src/routes/HomePage.js
+++ b/src/routes/HomePage.js
@@ -21,7 +21,7 @@ const HomeTitle = styled.div`
 	width: fit-content;
 `;
 
-const ADS_POSITION_OFFSET = 6
+const ADS_POSITION_OFFSET = 4
 
 const HomePage = (props) => {
 	const { fetchTarget, setFetchTarget } = props;


### PR DESCRIPTION
## Purpose / Description
<!--- Describe your changes in detail -->
- Increase ads frequency from 6 to 4 (show ads every 5 cards)
- Hide `google-auto-placed` from card list (all tabs, reviews, questions and recaps)
- Solution ref https://stackoverflow.com/a/73437879

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Changes made / Changes Checklist
<!--- Fix by doing something... -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots

Issue: Duplicate ads when switching tabs / Too many ads 
<img width="1944" height="914" alt="Screen Shot 2568-11-30 at 16 06 51" src="https://github.com/user-attachments/assets/988acaaa-ceb0-4c49-bb68-d37d8dcfca2d" />

Result: After disable auto placed ads and increase frequency
<img width="474" height="993" alt="Screen Shot 2568-11-30 at 16 08 37" src="https://github.com/user-attachments/assets/7cb0ff6a-77a8-4b03-b635-55cc22f77df1" />